### PR TITLE
Hoist the MD5 function with proper syntax

### DIFF
--- a/www.americanhistoryusa.com/static/js/campaign_trail.js
+++ b/www.americanhistoryusa.com/static/js/campaign_trail.js
@@ -3162,7 +3162,7 @@ document.addEventListener('keydown', function(event) {
 
 
 // MD5 Library
-var MD5 = function(d) {
+function MD5(d) {
 	try{
     var r = M(V(Y(X(d), 8 * d.length)));
     return r.toLowerCase()


### PR DESCRIPTION
The MD5 function needs to be defined before any usage of it, resulting in the entire script bombing out.

1) When a new user uses the website for the first time, no achievements are loaded.
2) The achievements function will try to use the MD5 function.
3) But because the MD5 function is defined at the bottom of the script, it cannot be accessed.
4) It needs to be a function definition to be hoisted.

This should be thoroughly reviewed, because I am not sure why it was defined as a variable in the first place. Was there an original reason for it?

closes #149 