### PR TITLE
Improve link colors on 1792

### DIFF
--- a/static/mods/1792_init.html
+++ b/static/mods/1792_init.html
@@ -12,6 +12,7 @@ campaignTrail_temp.credits = '/u/rekkotekko';
 document.getElementById("header").src = "https://i.imgur.com/tj5vGmn.png"
 nct_stuff.themes[nct_stuff.selectedTheme].coloring_title = "#4FB063"
 nct_stuff.themes[nct_stuff.selectedTheme].coloring_window = "#63A8D0"
+$(".footer a").css({"color":"#200000"});
 document.getElementsByClassName("game_header")[0].style.backgroundColor = nct_stuff.themes[nct_stuff.selectedTheme].coloring_title
 $(".container")[0].style.backgroundColor = "#FF7373"
 document.body.background = "https://i.imgur.com/D3jbXnG.jpg"


### PR DESCRIPTION
See title; red links don't work well on red backgrounds.

Not sure if the mod creator would be fine with this however, and I'm not really a prolific contributor to the community or anything lol, but thought it would be good to leave this here in case I can help in the future