### PR TITLE
Make code 2 fail to find candidate error message more clear

### DIFF
--- a/static/js/campaign_trail.js
+++ b/static/js/campaign_trail.js
@@ -1027,7 +1027,7 @@ function divideElectoralVotesProp(e, t) {
                 currCandData = copy(e.candidate_json[e.candidate_json.map(f=>f.pk).indexOf(Number(cand))]) // gets current candidate json data
 
                 if (!realCandidates.includes(Number(cand))) {
-                    alert("Unfortunately, this part of the mod is currently broken, and is unplayable. Apologies.")
+                    alert(`Error Loading Code 2: Cannot find candidate with PK ${Number(cand)}! Please make sure your candidate PKs are consistent between Code 1 and Code 2.`)
                     window.location.reload()
                 } else {
                     fakeId = cand


### PR DESCRIPTION
This is just a small PR that makes the code 2 failed to find candidate more clear for users. Myself and others on the Discord were initially confused by the message.

Here is a picture of the changes:

<img width="776" alt="image" src="https://github.com/newcampaigntrail/newcampaigntrail.github.io/assets/622443/f9a762c0-0df9-4fb2-afaf-17550f22ff58">
