### PR TITLE
Improves link colors on 1872

### DIFF
--- a/static/mods/1872_init.html
+++ b/static/mods/1872_init.html
@@ -14,6 +14,7 @@ document.getElementById("header").src = "https://media.discordapp.net/attachment
 nct_stuff.themes[nct_stuff.selectedTheme].coloring_title = "#152238"
 nct_stuff.themes[nct_stuff.selectedTheme].coloring_window = "#008080"
 document.getElementsByClassName("game_header")[0].style.backgroundColor = nct_stuff.themes[nct_stuff.selectedTheme].coloring_title
+$(".footer a").css({"color":"#050505"});
 $(".container")[0].style.backgroundColor = "#ff6289"
 document.body.background = "http://4.bp.blogspot.com/-pxz53vW61jE/VR8PATXOC6I/AAAAAAAACGQ/IxGo1xIh4Zo/s1600/View%2Bfrom%2Bthe%2BCapitol%2B01%2Bdetail.jpg"
 campaignTrail_temp.show_premium = true;


### PR DESCRIPTION
**Description:** Changes footer links on 1872 to black (with a blueish tint).

**Rationale:** Red colors don't go well with red backgrounds. Old (default) color was unreadable, this one is readable and also has the unintentional side effect of matching with the game header colors.