### PR TITLE
Fix 2024 VT on NCT

### DIFF
--- a/static/mods/2024 VT_DeanDemocratic Party.html
+++ b/static/mods/2024 VT_DeanDemocratic Party.html
@@ -7557,6 +7557,10 @@ function ctsAchievement(achievement, difficultyChecker = true){
     }
 }
 
+function unlockAchievement(name) {
+    jQuery.noop();
+}
+
 let observerRunning = false;
 let changeChartRunning = false;
 let mcaHeightRunning = false;

--- a/static/mods/2024 VT_ScottRepublican Party.html
+++ b/static/mods/2024 VT_ScottRepublican Party.html
@@ -8049,5 +8049,9 @@ function changechart(){
         }
     }
 
+	function unlockAchievement(name) {
+    	jQuery.noop();
+	}
+
 
  


### PR DESCRIPTION
2024 VT should no longer freeze with a placeholder "unlockAchievement" function that does nothing using jQuery's "noop()" function

PR has Ohas (coder)'s blessing